### PR TITLE
Fix looting. Body ignore feature. Loot log.

### DIFF
--- a/scripts/Grinder/Gui/BotSettings.lua
+++ b/scripts/Grinder/Gui/BotSettings.lua
@@ -22,6 +22,8 @@ BotSettings.TurninSelectedIndex = 0
 BotSettings.TurninName = { }
 BotSettings.TurninName = { }
 
+BotSettings.IgnoreBodyComboSelectedIndex = 0
+BotSettings.DeleteIgnoreBodyIndex = 0
 
 -----------------------------------------------------------------------------
 -- BotSettings Functions
@@ -102,6 +104,7 @@ function BotSettings.DrawBotSettings()
 			BotSettings.UpdateInventoryList()
             _, Bot.Settings.LootSettings.TakeLoot = ImGui.Checkbox("Take loots##id_guid_looting_take_loot", Bot.Settings.LootSettings.TakeLoot)
 			_, Bot.Settings.LootSettings.SkipLootPlayer = ImGui.Checkbox("Skip loot if player in range##id_guid_looting_IgnorePlayers", Bot.Settings.LootSettings.SkipLootPlayer)
+			_, Bot.Settings.LootSettings.LogLoot = ImGui.Checkbox("Log loot##id_guid_looting_log_loot", Bot.Settings.LootSettings.LogLoot)
 
 
             ImGui.Text("Always Delete these Items")
@@ -122,6 +125,29 @@ function BotSettings.DrawBotSettings()
                 end
             end
 
+            ImGui.Text("Do not loot these bodies")
+            BotSettings.UpdateMonsters()
+            valueChanged, BotSettings.IgnoreBodyComboSelectedIndex = ImGui.Combo("##id_guid_ignore_body_combo_select", BotSettings.IgnoreBodyComboSelectedIndex, BotSettings.MonsterNames)
+            if valueChanged and BotSettings.IgnoreBodyComboSelectedIndex > 0 then
+                local monsterName = BotSettings.MonsterNames[BotSettings.IgnoreBodyComboSelectedIndex]
+                Bot.Settings.LootSettings.IgnoreBodyName[monsterName] = true
+                BotSettings.IgnoreBodyComboSelectedIndex = 0
+            end
+
+            local ignoreBodyList = {}
+            for k,v in pairs(Bot.Settings.LootSettings.IgnoreBodyName) do
+            	table.insert(ignoreBodyList, k)
+        	end
+        	table.sort(ignoreBodyList)
+
+            _, BotSettings.DeleteIgnoreBodyIndex = ImGui.ListBox("##id_guid_delete_ignore_body", BotSettings.DeleteIgnoreBodyIndex, ignoreBodyList, 5)
+            if ImGui.Button("Remove Body##id_guid_remove_ignore_body", ImVec2(ImGui.GetContentRegionAvailWidth(), 20)) then
+                if BotSettings.DeleteIgnoreBodyIndex > 0 then
+                	local name = ignoreBodyList[BotSettings.DeleteIgnoreBodyIndex]
+                	Bot.Settings.LootSettings.IgnoreBodyName[name] = nil
+                	BotSettings.DeleteIgnoreBodyIndex = 0
+            	end
+            end
         end
 
 
@@ -427,14 +453,10 @@ function BotSettings.UpdateMonsters()
                 table.insert(BotSettings.MonsterNames, v.Name)
             end
         end
-            table.sort(BotSettings.MonsterNames)
-
+        table.sort(BotSettings.MonsterNames)
     end
 
 end
-
-
-
 
 function BotSettings.SaveCombatSettings()
     local json = JSON:new()

--- a/scripts/commonstates/v1/LootActor.lua
+++ b/scripts/commonstates/v1/LootActor.lua
@@ -43,7 +43,7 @@ function LootActorState:NeedToRun()
     if selfPlayer.Inventory.FreeSlots == 0 then
         return false
     end
-	
+    
 
     
 --    local nearestAttacker = self:GetNeareastAttacker()
@@ -59,14 +59,14 @@ function LootActorState:NeedToRun()
             Navigator.CanMoveTo(v.Position)
         then 
         
-			if self.Settings.SkipLootPlayer == true and v.Position.Distance3DFromMe > 500 and Bot.DetectPlayerAt(v.Position,1000) == true then
-				print("Skipped loot because of Player")
-				self.BlacklistActors[v.Guid] = Pyx.Win32.GetTickCount() - 30 * 1000
---				return false
-				else
-				self.CurrentLootActor = v
-				return true
-			end
+            if self.Settings.SkipLootPlayer == true and v.Position.Distance3DFromMe > 500 and Bot.DetectPlayerAt(v.Position,1000) == true then
+                print("Skipped loot because of Player")
+                self.BlacklistActors[v.Guid] = Pyx.Win32.GetTickCount() - 30 * 1000
+--              return false
+                else
+                self.CurrentLootActor = v
+                return true
+            end
             
         end
     end
@@ -80,22 +80,26 @@ function LootActorState:Run()
     local actorPosition = self.CurrentLootActor.Position
 
     if Looting.IsLooting then
+        local f = io.open(Pyx.Scripting.CurrentScript.Directory.."loot.txt", "a")
         local numLoots = Looting.ItemCount
         for i=0,numLoots-1 do 
             local lootItem = Looting.GetItemByIndex(i)
             if lootItem then
                 print("Loot item : " .. lootItem.ItemEnchantStaticStatus.Name)
                 Looting.Take(i)
+                if lootItem.ItemEnchantStaticStatus.Grade >= 1 then
+                    local name = BDOLua.Execute(string.format("return getActor(%i):get():getStaticStatusName()", self.CurrentLootActor.Key))
+                    f:write(string.format("%s - %s - %s\n", os.date(), name, lootItem.ItemEnchantStaticStatus.Name))
+                end
             end
         end
-        Looting.Close();
+        Looting.Close()
         if self.CallWhenCompleted then
             self.CallWhenCompleted(self)
         end
+        f:close()
         return true
-    end
-    
-    
+    end    
 
     if actorPosition.Distance3DFromMe > self.CurrentLootActor.BodySize + 150 then
         if self.CallWhileMoving then


### PR DESCRIPTION
Switch back to looting with an animation. However it glitches out and fails to work a few times so it falls back to the animation-less loot when it happens.

Loot blacklist logic has now been fixed but still needs to blacklist a body after X tries or seconds.

Loot logging to a file has been added. Currently only logs greens and up.